### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/bones-vanilla.yaml
+++ b/bones-vanilla.yaml
@@ -1,17 +1,7 @@
+enabled: true
 dropdown:
   enabled: false
-fontawesome:
-  enabled: true
-google_fonts_logo:
-  enabled: true
 google_prettify:
   enabled: true
-mobilemenu_breakpoint: large
+mobilemenu_breakpoint: medium
 mobilemenu_position: left
-
-streams:
-  schemes:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/bones-vanilla


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
