### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/bones-vanilla.yaml
+++ b/bones-vanilla.yaml
@@ -8,10 +8,3 @@ google_prettify:
   enabled: true
 mobilemenu_breakpoint: large
 mobilemenu_position: left
-
-streams:
-  schemes:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/bones-vanilla


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
